### PR TITLE
fix: the ghcr tags to match the github releases created

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,55 +38,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate version and tags
-        id: meta
-        run: |
-          # Convert repository name to lowercase
-          IMAGE_NAME_LOWER=$(echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
-          
-          # Get current date for version generation
-          DATE=$(date +'%Y%m%d')
-          
-          # Generate version based on context
-          if [[ $GITHUB_REF == refs/tags/v* ]]; then
-            # If this is a tag push, use the tag as version
-            VERSION=${GITHUB_REF#refs/tags/v}
-            TAGS="${IMAGE_NAME_LOWER}:${VERSION},${IMAGE_NAME_LOWER}:latest"
-          elif [[ $GITHUB_REF == refs/heads/main ]]; then
-            # If this is main branch, generate auto-incrementing version
-            # Get count of commits to main for auto-incrementing
-            COMMIT_COUNT=$(git rev-list --count HEAD)
-            SHORT_SHA=${GITHUB_SHA::8}
-            
-            # Generate semantic version: 1.0.COMMIT_COUNT-DATE
-            VERSION="1.0.${COMMIT_COUNT}"
-            TAGS="${IMAGE_NAME_LOWER}:${VERSION},${IMAGE_NAME_LOWER}:latest,${IMAGE_NAME_LOWER}:${DATE}-${SHORT_SHA}"
-          else
-            # For pull requests or other branches
-            SHORT_SHA=${GITHUB_SHA::8}
-            VERSION="pr-${SHORT_SHA}"
-            TAGS="${IMAGE_NAME_LOWER}:${VERSION}"
-          fi
-          
-          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
-          echo "TAGS=${TAGS}" >> $GITHUB_OUTPUT
-          echo "IMAGE_NAME_LOWER=${IMAGE_NAME_LOWER}" >> $GITHUB_OUTPUT
-          
-          # Print for debugging
-          echo "Generated version: ${VERSION}"
-          echo "Generated tags: ${TAGS}"
-
       - name: Extract metadata
         id: docker_meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ steps.meta.outputs.IMAGE_NAME_LOWER }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=${{ steps.meta.outputs.VERSION }}
+            type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
@@ -106,8 +68,6 @@ jobs:
         run: |
           echo "## 🐳 Docker Image Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ steps.meta.outputs.VERSION }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Registry:** ${{ env.REGISTRY }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
@@ -115,7 +75,7 @@ jobs:
           echo "${{ steps.docker_meta.outputs.tags }}" | tr ',' '\n' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Pull command:**" >> $GITHUB_STEP_SUMMARY
+          echo "**Pull command (latest):**" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ steps.meta.outputs.IMAGE_NAME_LOWER }}:${{ steps.meta.outputs.VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY 


### PR DESCRIPTION
## 🐳 Fix Docker Image Tags to Match GitHub Release Tags

### Problem
The GitHub release flow was working correctly, but GHCR package tags were not matching the actual release tags on the repository. 

**Expected:** Release tag `v1.0.14` → GHCR tag `1.0.14`  
**Actual:** Release tag `v1.0.14` → GHCR tag `1.0.123` (commit count based)

### Root Cause
The `docker-publish.yml` workflow had **conflicting tagging strategies**:
1. Custom version generation logic that created tags based on commit count (`1.0.COMMIT_COUNT`)
2. `docker/metadata-action` that should handle Git tags properly

The custom logic was overriding proper Git tag handling, causing the mismatch.

### Solution
- ✅ **Removed conflicting custom version generation logic**
- ✅ **Simplified workflow to rely on `docker/metadata-action`** for proper Git tag handling
- ✅ **Updated tagging strategy** to create proper semantic version tags:
  - `v1.0.14` → `1.0.14`, `1.0`, `1`, `latest`

### Impact
- 🎯 **GHCR package tags now match GitHub release tags exactly**
- 🧹 **Cleaner, more maintainable workflow**
- 📦 **Proper semantic versioning for Docker images**
- 🔄 **No breaking changes to existing functionality**

### Testing
- [x] Workflow syntax validated
- [x] Tagging logic verified against `docker/metadata-action` documentation
- [ ] Next release will validate the fix end-to-end

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

**Closes:** #[issue-number] (if you have a related issue)