### PR TITLE
fix: actually ?fix? the ghcr tag matching release tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,6 @@ name: Build and Publish Docker Image
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
   pull_request:
@@ -15,7 +13,9 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push:
+  # Job for release builds triggered by version tags
+  build-release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,31 +25,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history for version calculation
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
+      - name: Extract metadata for release
         id: docker_meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -57,16 +54,15 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Generate summary
-        if: github.event_name != 'pull_request'
+      - name: Generate release summary
         run: |
-          echo "## 🐳 Docker Image Published" >> $GITHUB_STEP_SUMMARY
+          echo "## 🐳 Docker Release Image Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Registry:** ${{ env.REGISTRY }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -75,7 +71,43 @@ jobs:
           echo "${{ steps.docker_meta.outputs.tags }}" | tr ',' '\n' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Pull command (latest):**" >> $GITHUB_STEP_SUMMARY
+          echo "**Pull command:**" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY 
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+
+  # Job for PR builds
+  build-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata for PR
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=pr
+
+      - name: Build Docker image (no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max 


### PR DESCRIPTION
## 🐳 Fix Docker Package Tags to Match GitHub Release Tags

### Problem
GHCR package tags were not matching GitHub release tags, causing version confusion for users.

**Expected:** Release tag `v1.1.1` → GHCR tag `1.1.1`  
**Actual:** Release tag `v1.1.1` → GHCR tag `1.0.14` (unrelated version)

### Root Cause
The Docker workflow was triggered by **both** main branch pushes and Git tag pushes, creating conflicting tagging strategies:
- Main branch pushes → Custom versioning (`1.0.X` based on commit count)  
- Git tag pushes → Proper semantic versioning (`1.1.1` from `v1.1.1`)

Since main pushes happened before release tags were created, the wrong versions were being published to GHCR.

### Solution
- ✅ **Removed main branch trigger** - Docker workflow now only runs on Git tag pushes
- ✅ **Split workflow into focused jobs:**
  - `build-release`: Runs on Git tags (`v*`) → Creates proper semantic versions
  - `build-pr`: Runs on PRs → Build-only for testing
- ✅ **Removed redundant dev builds** since every merge creates a release
- ✅ **Simplified workflow** with clear job separation

### Result
Now when you create release `v1.1.1`:
- 🎯 **GHCR gets:** `1.1.1`, `1.1`, `1`, `latest`
- 🎯 **GitHub release:** `v1.1.1`
- ✅ **Perfect match!**

### Impact
- 🔄 **GHCR package tags now exactly match GitHub release tags**
- 🧹 **Cleaner workflow with no redundant builds**
- 📦 **Proper semantic versioning for Docker images**
- 🚫 **No more version conflicts or confusion**

### Testing
- [x] Workflow syntax validated
- [x] Job conditions verified
- [x] Tagging strategy confirmed with `docker/metadata-action` docs
- [ ] Next release will validate the fix end-to-end

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

**Fixes:** Docker package versioning mismatch with GitHub releases