### PR TITLE
bug: only create directories on txt export

### DIFF
--- a/cmd/labelarr/main.go
+++ b/cmd/labelarr/main.go
@@ -283,8 +283,12 @@ func handleNormalMode(cfg *config.Config, processor *media.Processor, movieLibra
 						if err := exporter.FlushAll(); err != nil {
 							fmt.Printf("❌ Failed to write export files: %v\n", err)
 						} else {
-							fmt.Printf("✅ Successfully wrote export files to library subdirectories\n")
-							fmt.Printf("📊 Generated summary.txt with detailed statistics and file sizes\n")
+							if cfg.ExportMode == "json" {
+								fmt.Printf("✅ Successfully wrote export data to export.json\n")
+							} else {
+								fmt.Printf("✅ Successfully wrote export files to library subdirectories\n")
+								fmt.Printf("📊 Generated summary.txt with detailed statistics and file sizes\n")
+							}
 						}
 					} else {
 						fmt.Printf("📭 No matching items found for export labels\n")
@@ -292,8 +296,12 @@ func handleNormalMode(cfg *config.Config, processor *media.Processor, movieLibra
 						if err := exporter.FlushAll(); err != nil {
 							fmt.Printf("❌ Failed to create export files: %v\n", err)
 						} else {
-							fmt.Printf("✅ Created empty export files in library subdirectories\n")
-							fmt.Printf("📊 Generated summary.txt with export statistics\n")
+							if cfg.ExportMode == "json" {
+								fmt.Printf("✅ Created empty export.json file\n")
+							} else {
+								fmt.Printf("✅ Created empty export files in library subdirectories\n")
+								fmt.Printf("📊 Generated summary.txt with export statistics\n")
+							}
 						}
 					}
 				}

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -98,10 +98,12 @@ func (e *Exporter) SetCurrentLibrary(libraryName string) error {
 	sanitizedName := sanitizeFilename(libraryName)
 	e.currentLibrary = sanitizedName
 
-	// Create library-specific subdirectory if it doesn't exist
-	libraryPath := filepath.Join(e.exportLocation, sanitizedName)
-	if err := os.MkdirAll(libraryPath, 0755); err != nil {
-		return fmt.Errorf("failed to create library directory %s: %w", libraryPath, err)
+	// Only create library-specific subdirectory in txt mode
+	if e.exportMode == "txt" {
+		libraryPath := filepath.Join(e.exportLocation, sanitizedName)
+		if err := os.MkdirAll(libraryPath, 0755); err != nil {
+			return fmt.Errorf("failed to create library directory %s: %w", libraryPath, err)
+		}
 	}
 
 	// Initialize accumulated map for this library if it doesn't exist


### PR DESCRIPTION
## ✅ **Issues Fixed:**

### 1. **Removed unnecessary directory creation in JSON mode**
Modified `internal/export/export.go` in the `SetCurrentLibrary()` method to only create library subdirectories when using TXT mode. In JSON mode, no subdirectories are created since everything goes into a single `export.json` file.

### 2. **Fixed export success messages**
Updated `cmd/labelarr/main.go` to show dynamic messages based on the export mode:

**JSON Mode:**
- ✅ Successfully wrote export data to export.json
- ✅ Created empty export.json file (when no matches found)

**TXT Mode:**
- ✅ Successfully wrote export files to library subdirectories
- 📊 Generated summary.txt with detailed statistics and file sizes

## 🧪 **Testing:**
The build completed successfully, confirming the changes compile correctly.

Now when you run labelarr with `EXPORT_MODE=json`, you'll see:
- No mention of `.txt` files or `summary.txt` 
- No unnecessary library subdirectories created
- Appropriate messages about `export.json`